### PR TITLE
Save article xml as attribute to allow for processing after the fact

### DIFF
--- a/pymed/article.py
+++ b/pymed/article.py
@@ -24,6 +24,7 @@ class PubMedArticle(object):
         "results",
         "copyrights",
         "doi",
+        "xml",
     )
 
     def __init__(
@@ -135,6 +136,7 @@ class PubMedArticle(object):
         self.doi = self._extractDoi(xml_element)
         self.publication_date = self._extractPublicationDate(xml_element)
         self.authors = self._extractAuthors(xml_element)
+        self.xml = xml_element
 
     def toDict(self: object) -> dict:
         """ Helper method to convert the parsed information to a Python dict.


### PR DESCRIPTION
I've found that I often need to get additional data from an article. For this it would be helpful to have access to the original xml.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests (if applicable)? **not applicable**
2. [x] Have you lint your code locally prior to submission (use flake8)?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable? **not applicable**
* [ ] Have you successfully ran tests with your changes locally? **not applicable**
