### PR TITLE
Bugfix/article ID parsing issue

### DIFF
--- a/pymed/article.py
+++ b/pymed/article.py
@@ -47,7 +47,7 @@ class PubMedArticle(object):
                 self.__setattr__(field, kwargs.get(field, None))
 
     def _extractPubMedId(self: object, xml_element: TypeVar("Element")) -> str:
-        path = ".//ArticleId[@IdType='pubmed']"
+        path = "MedlineCitation/PMID"
         return getContent(element=xml_element, path=path)
 
     def _extractTitle(self: object, xml_element: TypeVar("Element")) -> str:


### PR DESCRIPTION
Thanks for the useful and well written library!

This minimal fix make the parser returning only the paper pubmed id.
Before, also the ids of the citations papers were returned.(they are within the ReferenceList element of the xml).

Fixes #22

An alternative XPath to be used:
path = ".//PubmedData/ArticleIdList/ArticleId[@IdType='pubmed']"

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests (if applicable)?
2. [x] Have you lint your code locally prior to submission (use flake8)?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
